### PR TITLE
Abc389

### DIFF
--- a/abc/abc386/b/b.py
+++ b/abc/abc386/b/b.py
@@ -1,0 +1,18 @@
+s = input()
+
+idx = 0
+cnt = 0 
+
+
+while idx < len(s):
+    if s[idx] == '0':
+        idx += 1
+        cnt += 1
+        if idx != len(s):
+            if s[idx] == '0':
+                idx += 1
+    else:
+        cnt += 1
+        idx += 1
+
+print(cnt)

--- a/abc/abc389/a/a.py
+++ b/abc/abc389/a/a.py
@@ -1,0 +1,3 @@
+s = input()
+
+print(int(s[0]) * int(s[2]))

--- a/abc/abc389/b/b.py
+++ b/abc/abc389/b/b.py
@@ -1,0 +1,6 @@
+import math
+x = int(input())
+ans = 0
+while math.factorial(ans) <= x:
+    ans += 1
+print(ans-1)

--- a/abc/abc389/c/c.py
+++ b/abc/abc389/c/c.py
@@ -1,0 +1,12 @@
+from collections import deque
+n = int(input())
+cumsum = deque([0])
+for _ in range(n):
+    op, *val = map(int,input().split(" "))
+    if op == 1:
+        cumsum.append(cumsum[-1] + val[0])
+    elif op == 2:
+        cumsum.popleft()
+    else:
+        # print("val",val)
+        print(cumsum[val[0]-1] - cumsum[0])


### PR DESCRIPTION
# ABC389
https://atcoder.jp/users/Argo11/history/share/abc389
# コンテスト参加結果

| 項目 | 内容 |
|------|------|
| コンテスト名 | トヨタ自動車プログラミングコンテスト2025（AtCoder Beginner Contest 389） |
| 順位 | 6832nd / 12393 |
| パフォーマンス | 421 |
| レーティング | 91 → **134** (**+43**) **Highest更新！** |
| 段級位 | 11 級 |

## A問題
やるだけ
9x9だから,2025年問題かなって思った

## B問題
`math.factorial`を1から順番にするだけ
TLEしそうだな～って思いながら書いたけど
`20! = 2.4×10^18`だからせいぜい20回ループするだけでいいので問題なしというお話(制約は3x10^8)
それはそれとして,もっと大きな数になったときは動的計画法とか２分探索が使えるっぽい.
### 動的計画法
答えを保存するテーブルを作成して,`table[-1] * val`していく方法

### ２分探索
答えのminとmaxを設定して２分探索を行うだけ

### C問題
累積和を使う問題,最初は馬鹿正直にQueueの出し入れだけで提出したけどTLE吐いたので改善した.
Claudeくん曰く良くないのはQueueをリストに変換する作業らしい(O(n)の計算量)
もとの数字を格納するqueueは必要なくて,累積和のqueueさえあればいいと気付いたのはコンテストが終わった後のおはなし
